### PR TITLE
Run CI with latest Julia version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,14 +19,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.7'] # , 'nightly']
+        julia-version: ['1'] # , 'nightly']
         julia-arch: [x64]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     env:
       JULIA_PKG_SERVER: ''
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Julia
         uses: julia-actions/setup-julia@v1
         with:
@@ -43,6 +43,6 @@ jobs:
       # - name: Process coverage
       #   uses: julia-actions/julia-processcoverage@v1
       # - name: Upload coverage
-      #   uses: codecov/codecov-action@v2
+      #   uses: codecov/codecov-action@v3
       #   with:
       #     files: lcov.info


### PR DESCRIPTION
Since the `Project` file requires v1.6, I would not test on v1.7. Either it should test the latest version (this PR) or the lowest version, or both.